### PR TITLE
Add Psichology Today verification badge to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,6 +5,13 @@
                 <h3>Carmen María Martín Fuentes</h3>
                 <p>Psicóloga General Sanitaria</p>
                 <p><strong>Nº Colegiada: {{ site.colegiada }}</strong></p>
+
+                <!-- Professional verification provided by Psychology Today -->
+                <div style="margin-top: 15px;">
+                    <a href="https://www.psychologytoday.com/profile/1606973" class="sx-verified-seal"></a>
+                    <script type="text/javascript" src="https://member.psychologytoday.com/verified-seal.js" data-badge="13" data-id="1606973" data-code="aHR0cHM6Ly93d3cucHN5Y2hvbG9neXRvZGF5LmNvbS9hcGkvdmVyaWZpZWQtc2VhbC9zZWFscy8xMy9wcm9maWxlLzE2MDY5NzM/Y2FsbGJhY2s9c3hjYWxsYmFjaw=="></script>
+                </div>
+                <!-- End Verification -->
             </div>
 
             <div class="footer-section">

--- a/sobre-mi.md
+++ b/sobre-mi.md
@@ -32,7 +32,7 @@ subtitle: Conoce mi trayectoria y enfoque terapéutico
         </p>
 
         <h2>¿Mi mayor privilegio? Trabajar en lo que más amo</h2>
-        
+
         <p>
             No todo el mundo tiene la suerte de levantarse cada día sabiendo que va a dedicar su tiempo a lo que realmente le apasiona. <strong>Mi gran afición es ayudar a las personas, y tengo el privilegio de vivir de ello.</strong>
         </p>


### PR DESCRIPTION
This PR aims to add a verification badge from Psicology Today to the page footer:

<img width="1127" height="389" alt="image" src="https://github.com/user-attachments/assets/c4c27bb0-b65c-4b50-bb60-f67f88ffde6a" />

